### PR TITLE
switch to deflate + zlib instead of gzip

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -462,6 +462,11 @@ for their valuable contributions, discussions and feedback to this specification
 # Document History
 {:numbered="false"}
 
+-01
+
+* Changing compression from gzip to zlib
+* Change typo in Status List Token sub claim description
+
 -00
 
 * Initial draft after working group adoption

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -131,7 +131,7 @@ Each status of a Referenced Token MUST be represented with a bit size of 1,2,4, 
 
 1. The overall Status List is encoded as a byte array. Depending on the bitsize, each byte corresponds to 8/(#bit-size) statuses (8,4,2, or 1). The status of each Referenced Token is identified using the index that maps to one or more specific bits within the byte array. The index starts counting at 0 and ends with "size" - 1 (being the last valid entry). The bits within an array are counted from least significant bit "0" to the most significant bit ("7"). All bits of the byte array at a particular index are set to a status value.
 
-2. The complete byte array is compressed using the "DEFLATE" {{RFC1951}} compression method and stored using the "ZLIB" {{RFC1950}} data format. Implementations SHOULD use the highest compression level available.
+2. The complete byte array is compressed using the "DEFLATE" {{RFC1951}} compression method and stored using the "ZLIB" {{RFC1950}} data format. Implementations are RECOMMENDED to use the highest compression level available.
 
 3. The result of the compression is then base64url-encoded, as defined in Section 2 of {{RFC7515}}.
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -27,7 +27,8 @@ normative:
   RFC7519: RFC7519
   RFC8392: RFC8392
   RFC3986: RFC3986
-  RFC1952: RFC1952
+  RFC1950: RFC1950
+  RFC1951: RFC1951
   RFC7515: RFC7515
   RFC6125: RFC6125
   RFC9110: RFC9110
@@ -130,9 +131,9 @@ Each status of a Referenced Token MUST be represented with a bit size of 1,2,4, 
 
 1. The overall Status List is encoded as a byte array. Depending on the bitsize, each byte corresponds to 8/(#bit-size) statuses (8,4,2, or 1). The status of each Referenced Token is identified using the index that maps to one or more specific bits within the byte array. The index starts counting at 0 and ends with "size" - 1 (being the last valid entry). The bits within an array are counted from least significant bit "0" to the most significant bit ("7"). All bits of the byte array at a particular index are set to a status value.
 
-2. The complete byte array is compressed using gZIP {{RFC1952}}.
+2. The complete byte array is compressed using the "DEFLATE" {{RFC1951}} compression method and stored using the "ZLIB" {{RFC1950}} data format. Implementations SHOULD use the highest compression level available.
 
-3. The result of the gZIP compression is then base64url-encoded, as defined in Section 2 of {{RFC7515}}.
+3. The result of the compression is then base64url-encoded, as defined in Section 2 of {{RFC7515}}.
 
 ## Referenced Token Format and Processing Requirements {#jwt-referenced-token}
 

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,6 @@ import util
 key = util.EXAMPLE_KEY
 iat = datetime.utcfromtimestamp(1686920170)
 exp = iat + timedelta(days=7000)
-gzip_time = iat.timestamp()
 folder = "./examples/"
 
 
@@ -29,7 +28,7 @@ def statusListEncoding1Bit():
     status_list.set(13, 1)
     status_list.set(14, 0)
     status_list.set(15, 1)
-    encoded = status_list.encode(mtime=gzip_time)
+    encoded = status_list.encode()
     text = 'byte_array = [{}, {}] \nencoded = "{}"'.format(
         hex(status_list.list[0]), hex(status_list.list[1]), encoded
     )
@@ -55,7 +54,7 @@ def exampleStatusList() -> StatusList:
 
 def statusListEncoding2Bit():
     status_list = exampleStatusList()
-    encoded = status_list.encode(mtime=gzip_time)
+    encoded = status_list.encode()
     text = 'byte_array = [{}, {}, {}] \nencoded = "{}"'.format(
         hex(status_list.list[0]),
         hex(status_list.list[1]),
@@ -74,7 +73,7 @@ def statusListJWT():
         key=key,
         bits=2,
     )
-    status_jwt = jwt.buildJWT(iat=iat, exp=exp, mtime=gzip_time)
+    status_jwt = jwt.buildJWT(iat=iat, exp=exp)
     text = util.formatToken(status_jwt, key)
     util.outputFile(folder + "status_list_jwt", text)
 

--- a/src/status_list.py
+++ b/src/status_list.py
@@ -1,5 +1,5 @@
 from base64 import urlsafe_b64decode, urlsafe_b64encode
-import gzip
+import zlib
 
 
 class StatusList:
@@ -20,13 +20,13 @@ class StatusList:
         new.decode(encoded)
         return new
 
-    def encode(self, mtime=None) -> str:
-        zipped = gzip.compress(self.list, mtime=mtime)
+    def encode(self) -> str:
+        zipped = zlib.compress(self.list, level=9)
         return urlsafe_b64encode(zipped).decode().strip("=")
 
     def decode(self, input: str):
         zipped = urlsafe_b64decode(f"{input}{'=' * divmod(len(input),4)[1]}")
-        self.list = bytearray(gzip.decompress(zipped))
+        self.list = bytearray(zlib.decompress(zipped))
         self.size = len(self.list) * self.divisor
 
     def set(self, pos: int, value: int):

--- a/src/status_token.py
+++ b/src/status_token.py
@@ -75,8 +75,7 @@ class StatusListToken:
         exp: datetime = None,
         optional_claims: Dict = None,
         optional_header: Dict = None,
-        compact=True,
-        mtime=None,
+        compact=True
     ) -> str:
         # build claims
         if optional_claims is not None:
@@ -88,7 +87,7 @@ class StatusListToken:
         claims["iat"] = int(iat.timestamp())
         if exp is not None:
             claims["exp"] = int(exp.timestamp())
-        encoded_list = self.list.encode(mtime=mtime)
+        encoded_list = self.list.encode()
         claims["status_list"] = {
             "bits": self.list.bits,
             "lst": encoded_list,


### PR DESCRIPTION
Closes #67 and #39.

## 📑 Description
Switches to zlib instead of gzip encoding and adds the recommendation to use the best available compression.

## Preview Link
[click here for rendered preview of PR](https://github.com/<repo-name>/<branch-name>/<draft-name>.html)