### PR TITLE
VALID does not precede J/CWT processing rules

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -187,6 +187,8 @@ Status types described by this specification comprise:
 
 The issuer of the Status List Token MUST choose an adequate "bits" (bit size) to be able to describe the required Status Types for the application.
 
+A Referenced Token for which the issuer is not tracking an explicit state like revoked, annulled, taken back, recalled, cancelled, or suspended may still be listed as 0x00 ("VALID") despite its JWT or CWT processing rules. The 0x00 ("VALID") status does not precede the Referenced Token's validity described by its JWT or CWT processing rules for claims such as "exp" (Expiration Time) or "nbf" (Not Before).
+
 # Example JWT Status Lists
 
 ## Example Status List with 1-Bit Status Values
@@ -446,6 +448,7 @@ To indicate that the content is an CWT-based Status List:
 
 We would like to thank
 Brian Campbell,
+Filip Skokan,
 Francesco Marino,
 Guiseppe De Marco,
 Kristina Yasuda,

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -187,7 +187,7 @@ Status types described by this specification comprise:
 
 The issuer of the Status List Token MUST choose an adequate "bits" (bit size) to be able to describe the required Status Types for the application.
 
-A Referenced Token for which the issuer is not tracking an explicit state like revoked, annulled, taken back, recalled, cancelled, or suspended may still be listed as 0x00 ("VALID") despite its JWT or CWT processing rules. The 0x00 ("VALID") status does not precede the Referenced Token's validity described by its JWT or CWT processing rules for claims such as "exp" (Expiration Time) or "nbf" (Not Before).
+The processing rules for JWT or CWT precede any evaluation of a referenced tokens status. For example if a token is evaluated as being expired through the "exp" (Expiration Time) but also has a status of 0x00 ("VALID"), the token is considered expired.
 
 # Example JWT Status Lists
 


### PR DESCRIPTION
This feedback comes from applying the Status List to an implementation of a general OAuth 2.x server issuing JWT Access Tokens.

Such implementation will typically not keep record of any issued JWT Access Tokens (their claims, expiry, etc) until they need to be revoked due any reason, e.g. getting leaked or just being explicitly revoked by the client.

In such cases the issuer considers the token as VALID when issuing the Status List but this state will not necessarily reflect the token's validity as per the JWT validation rules for claims like nbf or exp. This is important to point out so that the status list is not mistaken for an alternative to actually validating the referenced token's claim set.