### PR TITLE
Establish a mechanism that allows for other revocation means in the Referenced Token

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -97,7 +97,7 @@ The following rules apply to validating a JWT-based Status List Token. Applicati
 
 1. The JWT MUST contain an "iss" (issuer) claim that contains a unique string identifier for the entity that issued the JWT. In the absence of an application profile specifying otherwise, compliant applications MUST compare issuer values using the Simple String Comparison method defined in Section 6.2.1 of {{RFC3986}}. The value MUST be equal to that of the "iss" claim contained within the Referenced Token.
 
-2. The JWT MUST contain a "sub" (subject) claim that contains an unique string identifier for that Status List Token. The value MUST be equal to that of the "uri" claim contained in the "status" claim of the Referenced Token.
+2. The JWT MUST contain a "sub" (subject) claim that contains an unique string identifier for that Status List Token. The value MUST be equal to that of the "uri" claim contained in the "status_list" claim of the Referenced Token as defined in [](#jwt-referenced-token-status).
 
 3. The JWT MUST contain an "iat" (issued at) claim that identifies the time at which it was issued.
 
@@ -155,8 +155,10 @@ The following example is the decoded header and payload of a JWT meeting the pro
 {
   "iss": "https://example.com",
   "status": {
-    "idx": 0,
-    "uri": "https://example.com/statuslists/1"
+    "status_list": {
+      "idx": 0,
+      "uri": "https://example.com/statuslists/1"
+    }
   }
 }
 ~~~
@@ -167,9 +169,13 @@ The following rules apply to validating the "status" (status) claim
 
 1. The claim value MUST be a valid JSON object.
 
-2. The claim value object MUST contain an "idx" (index) member with a numeric value that represents the index to check for status information in the Status List for the current JWT. The value of this member MUST be a non-negative number, containing a value of zero or greater.
+2. The claim value object MUST contain a member called "status_list" that signals that status checks for this token can be done using the status list mechanism defined in this document. For the "status_list" object, the following rules apply:
 
-3. The claim value object MUST contain a "uri" member with a string value that identifies the Status List containing the status information for the JWT. The value of this member MUST be a uri conforming to {{RFC3986}}.
+    1. The claim value MUST be a valid JSON object.
+
+    2. The claim value object MUST contain an "idx" (index) member with a numeric value that represents the index to check for status information in the Status List for the current JWT. The value of this member MUST be a non-negative number, containing a value of zero or greater.
+
+    3. The claim value object MUST contain a "uri" member with a string value that identifies the Status List containing the status information for the JWT. The value of this member MUST be a uri conforming to {{RFC3986}}.
 
 # Status Types {#status-types}
 
@@ -467,6 +473,7 @@ for their valuable contributions, discussions and feedback to this specification
 
 -01
 
+* Change status claim to in referenced token to allow re-use for other mechanisms
 * Changing compression from gzip to zlib
 * Change typo in Status List Token sub claim description
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -245,21 +245,6 @@ The following is a non-normative example for a decoded header and payload of a R
 }
 ~~~
 
-### Status Claim Format {#jwt-referenced-token-status}
-
-The following rules apply to validating the "status" (status) claim
-
-1. The claim value MUST be a valid JSON object.
-
-2. The claim value object MUST contain a member called "status_list" that signals that status checks for this token can be done using the status list mechanism defined in this document. For the "status_list" object, the following rules apply:
-
-    1. The claim value MUST be a valid JSON object.
-
-    2. The claim value object MUST contain an "idx" (index) member with a numeric value that represents the index to check for status information in the Status List for the current JWT. The value of this member MUST be a non-negative number, containing a value of zero or greater.
-
-    3. The claim value object MUST contain a "uri" member with a string value that identifies the Status List containing the status information for the JWT. The value of this member MUST be a uri conforming to {{RFC3986}}.
-
-
 # Status Types {#status-types}
 
 This document defines potential statuses of Referenced Tokens as Status Type values. If the Status List contains more than one bit per token (as defined by "bits" in the Status List), then the whole value of bits MUST describe one value. A Status List can not represent multiple statuses per Referenced Token.

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -36,6 +36,7 @@ normative:
 informative:
   RFC6749: RFC6749
   RFC7662: RFC7662
+  RFC7800: RFC7800
 
 --- abstract
 
@@ -81,7 +82,7 @@ Revocation mechanisms are an essential part for most identity ecosystems. In the
 
 This specification seeks to find a balance between scalability, security, and privacy by minimizing the status information to mere bits (often a single bit) and compressing the resulting binary data. Thereby, a Status List may contain statuses of many thousands or millions Referenced Tokens while remaining as small as possible. Placing large amounts of Referenced Tokens into the same list also enables herd privacy relative to the Issuer.
 
-There will likely be different mechanisms to convey token/credential status information in the foreseeable future depending on specific use-cases and their requirements. The way this information is transported in the token is defined with possible re-use or extension in mind.
+This specification establishes the IANA "Status Mechanism Methods" registry for status mechanism in  and registers the members defined by this specification. Other specifications can register other members used for confirmation, including other members for conveying proof-of-possession keys using different key representations.
 
 ## Design Considerations
 
@@ -225,6 +226,10 @@ The following is a non-normative example for a Status List Token in JWT format:
 TBD
 
 # Referenced Token {#referenced-token}
+
+## Status Claim {#status-claim}
+
+By including a "status" claim in a JWT, the issuer of the JWT declares that the credential is referencing a mechanism to retrieve status information about this credential. The claim contains members used to reference to a status list as defined in this specification. Other members of the "status" object may be defined because status list means to check the status of a credential. This is analogous to "cnf" claim in Section 3.1 of {{RFC7800}} in which different authenticity confirmation methods can be included.
 
 ## Referenced Token in JWT Format {#referenced-token-jwt}
 
@@ -428,14 +433,18 @@ IANA "JSON Web Token Claims" registry [@IANA.JWT] established by [@!RFC7519].
 *  Claim Name: `status`
 *  Claim Description: Reference to a status or validity mechanism containing up-to-date status information on the JWT.
 *  Change Controller: IETF
-*  Specification Document(s):  [[ (#referenced-token-jwt) of this specification ]]
+*  Specification Document(s):  [](#status-claim) of this specification
 
 <br/>
 
 *  Claim Name: `status_list`
 *  Claim Description: A status list containing up-to-date status information on multiple other JWTs encoded as a bitarray.
 *  Change Controller: IETF
-*  Specification Document(s):  [[ (#status-list-json) of this specification ]]
+*  Specification Document(s):  [](#status-list-json) of this specification
+
+## JWT Confirmation Methods Registry {#iana-registry}
+
+This specification establishes the IANA "Status Mechanism Methods" registry for JWT "status" member values. The registry records the status mechanism method member and a reference to the specification that defines it.
 
 ## Media Type Registration
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -430,21 +430,41 @@ TBD Declare whether JWT and CWT representations can be used interchangeably by t
 This specification requests registration of the following Claims in the
 IANA "JSON Web Token Claims" registry [@IANA.JWT] established by [@!RFC7519].
 
+### Registry Contents
+
 *  Claim Name: `status`
 *  Claim Description: Reference to a status or validity mechanism containing up-to-date status information on the JWT.
 *  Change Controller: IETF
 *  Specification Document(s):  [](#status-claim) of this specification
 
-<br/>
-
-*  Claim Name: `status_list`
-*  Claim Description: A status list containing up-to-date status information on multiple other JWTs encoded as a bitarray.
-*  Change Controller: IETF
-*  Specification Document(s):  [](#status-list-json) of this specification
-
-## JWT Confirmation Methods Registry {#iana-registry}
+## JWT Status Mechanism Methods Registry {#iana-registry}
 
 This specification establishes the IANA "Status Mechanism Methods" registry for JWT "status" member values. The registry records the status mechanism method member and a reference to the specification that defines it.
+
+### Registration Template
+
+Status Method Value:
+
+  > The name requested (e.g., "status_list"). The name is case sensitive. Names may not match other registered names in a case-insensitive manner unless the Designated Experts state that there is a compelling reason to allow an exception.
+
+Status Method Description:
+
+  > Brief description of the status mechanism method.
+
+Change Controller:
+
+  > For Standards Track RFCs, list the "IESG".  For others, give the name of the responsible party.  Other details (e.g., postal address, email address, home page URI) may also be included.
+
+Specification Document(s):
+
+  > Reference to the document or documents that specify the parameter, preferably including URIs that can be used to retrieve copies of the documents.  An indication of the relevant sections may also be included but is not required.
+
+### Initial Registry Contents
+
+*  Status Method Value: `status_list`
+*  Status Method Description: A status list containing up-to-date status information on multiple other JWTs encoded as a bitarray.
+*  Change Controller: IETF
+*  Specification Document(s):  [](#referenced-token-jwt) of this specification
 
 ## Media Type Registration
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -33,6 +33,7 @@ normative:
   RFC6125: RFC6125
   RFC9110: RFC9110
   RFC9111: RFC9111
+  IANA.JWT: IANA.JWT
 informative:
   RFC6749: RFC6749
   RFC7662: RFC7662
@@ -428,7 +429,7 @@ TBD Declare whether JWT and CWT representations can be used interchangeably by t
 ## JSON Web Token Claims Registration
 
 This specification requests registration of the following Claims in the
-IANA "JSON Web Token Claims" registry [@IANA.JWT] established by [@!RFC7519].
+IANA "JSON Web Token Claims" registry {{IANA.JWT}} established by {{RFC7519}}.
 
 ### Registry Contents
 
@@ -599,7 +600,7 @@ for their valuable contributions, discussions and feedback to this specification
 * renamed Verifier to Relying Party
 * added IANA consideration
 
-[draft-ietf-oauth-status-list ]
+\[ draft-ietf-oauth-status-list \]
 
 -01
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -81,6 +81,8 @@ Revocation mechanisms are an essential part for most identity ecosystems. In the
 
 This specification seeks to find a balance between scalability, security, and privacy by minimizing the status information to mere bits (often a single bit) and compressing the resulting binary data. Thereby, a Status List may contain statuses of many thousands or millions Referenced Tokens while remaining as small as possible. Placing large amounts of Referenced Tokens into the same list also enables herd privacy relative to the Issuer.
 
+There will likely be different mechanisms to convey token/credential status information in the foreseeable future depending on specific use-cases and their requirements. The way this information is transported in the token is defined with possible re-use or extension in mind.
+
 ## Design Considerations
 
 The decisions taken in this specification aim to achieve the following design goals:
@@ -92,6 +94,7 @@ The decisions taken in this specification aim to achieve the following design go
 * the Status List shall enable caching policies and offline support
 * the specification shall support JSON and CBOR based tokens
 * the specification shall not specify key resolution or trust frameworks
+* the specification shall design a mechanism to convey information about the validity status of a token/credential that can be re-used/expanded upon
 
 # Conventions and Definitions
 
@@ -230,7 +233,7 @@ The Referenced Token MUST be encoded as a "JSON Web Token (JWT)" according to {{
 The following content applies to the JWT Claims Set:
 
 * `iss`: REQUIRED. The `iss` (issuer) claim MUST specify a unique string identifier for the entity that issued the Referenced Token. In the absence of an application profile specifying otherwise, compliant applications MUST compare issuer values using the Simple String Comparison method defined in Section 6.2.1 of {{RFC3986}}. The value MUST be equal to that of the `iss` claim contained within the referenced Status List Token.
-* `status`: REQUIRED. The `status` (status) claim MUST specify a JSON Object that contains a reference to a status mechanism.
+* `status`: REQUIRED. The `status` (status) claim MUST specify a JSON Object that contains at least one reference to a status mechanism.
   * `status_list`: REQUIRED when the status list mechanism defined in this specification is used. It contains a reference to a Status List or Status List Token. The object contains exactly two claims:
     * `idx`: REQUIRED. The `idx` (index) claim MUST specify an Integer that represents the index to check for status information in the Status List for the current Referenced Token. The value of `idx` MUST be a non-negative number, containing a value of zero or greater.
     * `uri`: REQUIRED. The `uri` (URI) claim MUST specify a String value that identifies the Status List or Status List Token containing the status information for the Referenced Token. The value of `uri` MUST be a URI conforming to {{RFC3986}}.
@@ -423,7 +426,7 @@ This specification requests registration of the following Claims in the
 IANA "JSON Web Token Claims" registry [@IANA.JWT] established by [@!RFC7519].
 
 *  Claim Name: `status`
-*  Claim Description: Reference to a status list containing up-to-date status information on the JWT.
+*  Claim Description: Reference to a status or validity mechanism containing up-to-date status information on the JWT.
 *  Change Controller: IETF
 *  Specification Document(s):  [[ (#referenced-token-jwt) of this specification ]]
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -82,7 +82,7 @@ Revocation mechanisms are an essential part for most identity ecosystems. In the
 
 This specification seeks to find a balance between scalability, security, and privacy by minimizing the status information to mere bits (often a single bit) and compressing the resulting binary data. Thereby, a Status List may contain statuses of many thousands or millions Referenced Tokens while remaining as small as possible. Placing large amounts of Referenced Tokens into the same list also enables herd privacy relative to the Issuer.
 
-This specification establishes the IANA "Status Mechanism Methods" registry for status mechanism in  and registers the members defined by this specification. Other specifications can register other members used for confirmation, including other members for conveying proof-of-possession keys using different key representations.
+This specification establishes the IANA "Status Mechanism Methods" registry for status mechanism and registers the members defined by this specification. Other specifications can register other members used for status retrieval.
 
 ## Design Considerations
 
@@ -95,7 +95,7 @@ The decisions taken in this specification aim to achieve the following design go
 * the Status List shall enable caching policies and offline support
 * the specification shall support JSON and CBOR based tokens
 * the specification shall not specify key resolution or trust frameworks
-* the specification shall design a mechanism to convey information about the validity status of a token/credential that can be re-used/expanded upon
+* the specification shall design an extension point to convey information about the status of a token that can be re-used by other mechanisms
 
 # Conventions and Definitions
 

--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -229,7 +229,7 @@ TBD
 
 ## Status Claim {#status-claim}
 
-By including a "status" claim in a JWT, the issuer of the JWT declares that the credential is referencing a mechanism to retrieve status information about this credential. The claim contains members used to reference to a status list as defined in this specification. Other members of the "status" object may be defined because status list means to check the status of a credential. This is analogous to "cnf" claim in Section 3.1 of {{RFC7800}} in which different authenticity confirmation methods can be included.
+By including a "status" claim in a Referenced Token, the issuer is referencing a mechanism to retrieve status information about this Referenced Token. The claim contains members used to reference to a status list as defined in this specification. Other members of the "status" object may be defined by other specifications. This is analogous to "cnf" claim in Section 3.1 of {{RFC7800}} in which different authenticity confirmation methods can be included.
 
 ## Referenced Token in JWT Format {#referenced-token-jwt}
 


### PR DESCRIPTION
Establish a mechanism that allows for other revocation means in the Referenced Token as discussed in #85. The only thing i changed was to call the reference "status_list" but I am open to change it to "status_bitstring" if we think that is a better fit.

Closes #85 

## Preview Link
[click here for rendered preview of PR](https://vcstuff.github.io/draft-ietf-oauth-status-list/c2bo/status-reference/draft-ietf-oauth-status-list.html)