### PR TITLE
added newline to fix rendering for history

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -549,6 +549,7 @@ for their valuable contributions, discussions and feedback to this specification
 {:numbered="false"}
 
 -01
+
 * add design consideration to the introduction
 * restructure the sections of this document
 * add option to return an unsigned Status List


### PR DESCRIPTION
## 📑 Description
fixes the rendering of the last history (01)

## Preview Link

[click here for rendered preview of PR](https://vcstuff.github.io/draft-ietf-oauth-status-list/c2bo/history-rendering/draft-ietf-oauth-status-list.html)