### PR TITLE
fix eudi-wallet-it-python status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Command line usage requires that you have the necessary software installed.  See
 | [OWF sd-jwt-js](https://github.com/openwallet-foundation/sd-jwt-js)                                               | TypeScript | yes    | yes    | yes           |
 | [Adorsys status-list-server](https://github.com/adorsys/status-list-server)                                       | Rust       | yes    | no     | no            |
 | [Bundesdruckerei issuer](https://github.com/Bundesdruckerei-GmbH/pid-issuer/tree/main/status-list-service-0.1.11) | Kotlin     | yes    | yes    | yes           |
-| [eudi-wallet-it-python](https://github.com/italia/eudi-wallet-it-python/blob/main/pyeudiw/status_list)            | Python     | no     | yes    | no            |
+| [eudi-wallet-it-python](https://github.com/italia/eudi-wallet-it-python/blob/main/pyeudiw/status_list)            | Python     | yes     | no    | yes            |
 
 
 ## Testing


### PR DESCRIPTION
this PR clarifies the scopes of https://github.com/italia/eudi-wallet-it-python that implements both a RP and a VCI

status list code:
    https://github.com/italia/eudi-wallet-it-python/blob/dev/pyeudiw/status_list/__init__.py
    
 openid4vp:
    https://github.com/italia/eudi-wallet-it-python/tree/dev/pyeudiw/satosa/backends
    
 openid4vci:
    https://github.com/italia/eudi-wallet-it-python/tree/dev/pyeudiw/satosa/frontends