### PR TITLE
fix typos

### DIFF
--- a/draft-ietf-oauth-status-list.md
+++ b/draft-ietf-oauth-status-list.md
@@ -1523,6 +1523,7 @@ Oliver Terbu,
 Orie Steele,
 Rifaat Shekh-Yusef,
 Rohan Mahy,
+Takahiko Kawasaki,
 Timo Glastra
 and
 Torsten Lodderstedt


### PR DESCRIPTION
Closes #325 

I didn't change this part, everything else should be there:

> ❌ for this type of Referenced Token or Issuer
✅ for this type of Referenced Token

This formulation was intentional if I recall correctly.

@TakahikoKawasaki I added your name to the acknowledgements section, I hope that is ok for you?
